### PR TITLE
data_stream_router_processor commits-as-review

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RerouteProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RerouteProcessor.java
@@ -265,10 +265,5 @@ public final class RerouteProcessor extends AbstractProcessor {
                 return value;
             }
         }
-
-        @Override
-        public String toString() {
-            return value;
-        }
     }
 }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RerouteProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RerouteProcessor.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationException;
@@ -191,8 +192,12 @@ public final class RerouteProcessor extends AbstractProcessor {
      */
     static final class DataStreamValueSource {
 
-        private static final char[] DISALLOWED_IN_DATASET = new char[] { '\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',', '#', ':', '-' };
-        private static final char[] DISALLOWED_IN_NAMESPACE = new char[] { '\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',', '#', ':' };
+        private static final Pattern DISALLOWED_IN_DATASET = pattern(
+            new char[] { '\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',', '#', ':', '-' }
+        );
+        private static final Pattern DISALLOWED_IN_NAMESPACE = pattern(
+            new char[] { '\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',', '#', ':' }
+        );
         static final DataStreamValueSource DATASET_VALUE_SOURCE = dataset("{{" + DATA_STREAM_DATASET + "}}");
         static final DataStreamValueSource NAMESPACE_VALUE_SOURCE = namespace("{{" + DATA_STREAM_NAMESPACE + "}}");
 
@@ -208,16 +213,17 @@ public final class RerouteProcessor extends AbstractProcessor {
             return new DataStreamValueSource(namespace, nsp -> sanitizeDataStreamField(nsp, DISALLOWED_IN_NAMESPACE));
         }
 
-        private static String sanitizeDataStreamField(String s, char[] disallowedInDataset) {
+        private static String sanitizeDataStreamField(String s, Pattern disallowedInDataset) {
             if (s == null) {
                 return null;
             }
             s = s.toLowerCase(Locale.ROOT);
             s = s.substring(0, Math.min(s.length(), MAX_LENGTH));
-            for (char c : disallowedInDataset) {
-                s = s.replace(c, REPLACEMENT_CHAR);
-            }
-            return s;
+            return disallowedInDataset.matcher(s).replaceAll(String.valueOf(REPLACEMENT_CHAR));
+        }
+
+        private static Pattern pattern(char[] disallowedInDataset) {
+            return Pattern.compile("[" + Pattern.quote(String.valueOf(disallowedInDataset)) + "]");
         }
 
         private DataStreamValueSource(String value, Function<String, String> sanitizer) {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RerouteProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RerouteProcessorFactoryTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ingest.common.RerouteProcessor.DataStreamValueSource;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
@@ -21,14 +22,8 @@ public class RerouteProcessorFactoryTests extends ESTestCase {
 
     public void testDefaults() throws Exception {
         RerouteProcessor processor = create(null, null);
-        assertThat(
-            processor.getDataStreamDataset().stream().map(RerouteProcessor.DataStreamValueSource::toString).toList(),
-            equalTo(List.of("{{data_stream.dataset}}"))
-        );
-        assertThat(
-            processor.getDataStreamNamespace().stream().map(RerouteProcessor.DataStreamValueSource::toString).toList(),
-            equalTo(List.of("{{data_stream.namespace}}"))
-        );
+        assertThat(processor.getDataStreamDataset(), equalTo(List.of(DataStreamValueSource.DATASET_VALUE_SOURCE)));
+        assertThat(processor.getDataStreamNamespace(), equalTo(List.of(DataStreamValueSource.NAMESPACE_VALUE_SOURCE)));
     }
 
     public void testInvalidDataset() throws Exception {


### PR DESCRIPTION
The first commit drops the `toString` method from `RerouteProcessor.DataStreamValueSource` -- as far as I could tell, the only place it was being used was in the tests. The test in question is based on object identity now, rather than toString-equality.

The second commit is a (premature?) optimization -- rather than doing M scans of the N-character string, it statically compiles a regex for the characters in question and then applies that to the string once. We could certainly chat about whether this is worth bothering to do, of course it's perfectly reasonable to punt this off as just being a premature optimization. That said, though, I thought the tests of this logic seemed a bit soft -- my replacement code passes tests, but does it actually work the same? It's hard to tell. Does that mean there should be more tests of this? Anyway, more of a discussion-or-thinking-aloud than a literal "please apply this commit". 